### PR TITLE
fix: Dedupe task references in consecutive updates

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -73173,6 +73173,7 @@ async function addComment(client, taskId, comment) {
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Added the GitHub link to the Asana task: ${taskId}`);
 }
 function getPreviousText() {
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(JSON.stringify(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload));
     if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.action === 'edited') {
         return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -73174,21 +73174,19 @@ async function addComment(client, taskId, comment) {
 }
 function getPreviousText() {
     if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.action === 'edited') {
-        return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes.body.from;
+        return { text: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes.body.from };
     }
-    return null;
+    return {};
 }
-function extractGitHubEventParameters() {
+function getCurrentTextAndUrl() {
     const pullRequest = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request;
     const issue = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.issue;
     const comment = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.comment;
-    const previous = getPreviousText();
     if (pullRequest) {
         (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Extracting information from PR: ${pullRequest.html_url}`);
         return {
             url: pullRequest.html_url,
             text: pullRequest.body,
-            previous,
         };
     }
     else if (issue && comment) {
@@ -73196,7 +73194,6 @@ function extractGitHubEventParameters() {
         return {
             url: comment.html_url,
             text: comment.body,
-            previous,
         };
     }
     throw new Error('Must be used on pull_request and issue_comment events only');
@@ -73223,9 +73220,10 @@ async function main() {
     if (!personalAccessToken) {
         throw new Error('Asana personal access token (asana-pat) not specified');
     }
-    const { url, text, previous } = extractGitHubEventParameters();
-    const previousTasks = (_a = (previous && extractTasks(previous))) !== null && _a !== void 0 ? _a : new Set();
+    const { url, text } = getCurrentTextAndUrl();
     const currentTasks = extractTasks(text);
+    const { text: previous } = getPreviousText();
+    const previousTasks = (_a = (previous && extractTasks(previous))) !== null && _a !== void 0 ? _a : new Set();
     const tasks = difference(currentTasks, previousTasks);
     const deduped = currentTasks.size - tasks.size;
     if (deduped > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -73172,15 +73172,23 @@ async function addComment(client, taskId, comment) {
     await client.tasks.addComment(taskId, { text: comment });
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Added the GitHub link to the Asana task: ${taskId}`);
 }
+function getPreviousText() {
+    if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.action === 'edited') {
+        return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes;
+    }
+    return null;
+}
 function extractGitHubEventParameters() {
     const pullRequest = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request;
     const issue = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.issue;
     const comment = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.comment;
+    const previous = getPreviousText();
     if (pullRequest) {
         (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Extracting information from PR: ${pullRequest.html_url}`);
         return {
             url: pullRequest.html_url,
             text: pullRequest.body,
+            previous,
         };
     }
     else if (issue && comment) {
@@ -73188,6 +73196,7 @@ function extractGitHubEventParameters() {
         return {
             url: comment.html_url,
             text: comment.body,
+            previous,
         };
     }
     throw new Error('Must be used on pull_request and issue_comment events only');
@@ -73197,7 +73206,8 @@ async function main() {
     if (!personalAccessToken) {
         throw new Error('Asana personal access token (asana-pat) not specified');
     }
-    const { url, text } = extractGitHubEventParameters();
+    const { url, text, previous } = extractGitHubEventParameters();
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(JSON.stringify(previous));
     const tasks = new Set();
     let rawParseUrl;
     while ((rawParseUrl = ASANA_TASK_LINK_REGEX.exec(text)) !== null) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -73173,9 +73173,8 @@ async function addComment(client, taskId, comment) {
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Added the GitHub link to the Asana task: ${taskId}`);
 }
 function getPreviousText() {
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(JSON.stringify(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload));
     if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.action === 'edited') {
-        return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes;
+        return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes.body.from;
     }
     return null;
 }
@@ -73202,20 +73201,38 @@ function extractGitHubEventParameters() {
     }
     throw new Error('Must be used on pull_request and issue_comment events only');
 }
-async function main() {
-    const personalAccessToken = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('asana-pat');
-    if (!personalAccessToken) {
-        throw new Error('Asana personal access token (asana-pat) not specified');
-    }
-    const { url, text, previous } = extractGitHubEventParameters();
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(JSON.stringify(previous));
+function extractTasks(text) {
+    ASANA_TASK_LINK_REGEX.lastIndex = 0;
     const tasks = new Set();
     let rawParseUrl;
     while ((rawParseUrl = ASANA_TASK_LINK_REGEX.exec(text)) !== null) {
         tasks.add(rawParseUrl.groups.taskId);
     }
+    return tasks;
+}
+function difference(setA, setB) {
+    let diff = new Set(setA);
+    for (let elem of setB) {
+        diff.delete(elem);
+    }
+    return diff;
+}
+async function main() {
+    var _a;
+    const personalAccessToken = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('asana-pat');
+    if (!personalAccessToken) {
+        throw new Error('Asana personal access token (asana-pat) not specified');
+    }
+    const { url, text, previous } = extractGitHubEventParameters();
+    const previousTasks = (_a = (previous && extractTasks(previous))) !== null && _a !== void 0 ? _a : new Set();
+    const currentTasks = extractTasks(text);
+    const tasks = difference(currentTasks, previousTasks);
+    const deduped = tasks.size - currentTasks.size;
+    if (deduped > 0) {
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Deduplicated ${deduped} tasks`);
+    }
     if (tasks.size === 0) {
-        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)('No Asana tasks referenced. Done.');
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)('No new Asana tasks referenced. Done.');
         return;
     }
     const options = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -73174,7 +73174,7 @@ async function addComment(client, taskId, comment) {
 }
 function getPreviousText() {
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(JSON.stringify(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload));
-    if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.action === 'edited') {
+    if (_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.action === 'edited') {
         return _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.changes;
     }
     return null;

--- a/dist/index.js
+++ b/dist/index.js
@@ -73227,7 +73227,7 @@ async function main() {
     const previousTasks = (_a = (previous && extractTasks(previous))) !== null && _a !== void 0 ? _a : new Set();
     const currentTasks = extractTasks(text);
     const tasks = difference(currentTasks, previousTasks);
-    const deduped = tasks.size - currentTasks.size;
+    const deduped = currentTasks.size - tasks.size;
     if (deduped > 0) {
         (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Deduplicated ${deduped} tasks`);
     }

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ async function addComment(client: Client, taskId: string, comment: string): Prom
 }
 
 function getPreviousText(): string | null {
+  info(JSON.stringify(context.payload));
   if (context.action === 'edited') {
     return context.payload.changes;
   }

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ async function addComment(client: Client, taskId: string, comment: string): Prom
 
 function getPreviousText(): string | null {
   info(JSON.stringify(context.payload));
-  if (context.action === 'edited') {
+  if (context.payload.action === 'edited') {
     return context.payload.changes;
   }
 

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,7 @@ async function main() {
   const previousTasks = (previous && extractTasks(previous)) ?? new Set<string>();
   const currentTasks = extractTasks(text);
   const tasks = difference(currentTasks, previousTasks);
-  const deduped = tasks.size - currentTasks.size;
+  const deduped = currentTasks.size - tasks.size;
   if (deduped > 0) {
     info(`Deduplicated ${deduped} tasks`);
   }


### PR DESCRIPTION
Detect references to the same Asana tasks in consecutive updates, and prevent adding comments to them. Should greatly reduce the number of duplicate comments.